### PR TITLE
Removed unused/unneeded "from matplotlib import pyplot"

### DIFF
--- a/python/lsst/meas/modelfit/display/interactive.py
+++ b/python/lsst/meas/modelfit/display/interactive.py
@@ -25,8 +25,6 @@ import os
 import collections
 import numpy
 import copy
-import matplotlib.colors
-import mpl_toolkits.mplot3d
 
 import lsst.pipe.base
 import lsst.pex.config

--- a/python/lsst/meas/modelfit/display/interactive.py
+++ b/python/lsst/meas/modelfit/display/interactive.py
@@ -110,6 +110,7 @@ class Interactive(object):
     def plotDistribution(self, *records):
         """Plot a representation of the posterior distribution from a ModelFitRecord.
         """
+        import matplotlib
         recordId = records[0].getId()
         figure = matplotlib.pyplot.figure(recordId, figsize=(10, 10))
         data = {}

--- a/python/lsst/meas/modelfit/display/interactive.py
+++ b/python/lsst/meas/modelfit/display/interactive.py
@@ -25,7 +25,6 @@ import os
 import collections
 import numpy
 import copy
-from matplotlib import pyplot
 import matplotlib.colors
 import mpl_toolkits.mplot3d
 

--- a/python/lsst/meas/modelfit/display/optimizerDisplay.py
+++ b/python/lsst/meas/modelfit/display/optimizerDisplay.py
@@ -22,7 +22,9 @@
 
 import numpy
 import matplotlib
+import matplotlib.colors
 from mpl_toolkits.axes_grid1 import make_axes_locatable
+import mpl_toolkits.mplot3d
 
 from .densityPlot import mergeDefaults, hide_xticklabels, hide_yticklabels
 from .. import modelfitLib

--- a/tests/testMeasureImage.py
+++ b/tests/testMeasureImage.py
@@ -25,7 +25,6 @@
 import os
 import unittest
 import numpy
-import matplotlib
 import copy
 
 import lsst.pex.logging

--- a/tests/testSoftenedLinearPrior.py
+++ b/tests/testSoftenedLinearPrior.py
@@ -30,7 +30,6 @@ import lsst.utils.tests
 import lsst.shapelet
 import lsst.afw.geom.ellipses
 import lsst.meas.modelfit
-from matplotlib import pyplot
 
 try:
     import scipy.integrate


### PR DESCRIPTION
Passes buildbot 
http://lsst-buildx.ncsa.illinois.edu:8010/builders/DM_stack/builds/5664

This is just a trivial removal of two unused "from matplotlib import pyplot" lines.

No need for consideration of the discussion at
https://jira.lsstcorp.org/browse/DM-2588