### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/include/lsst/meas/modelfit/ModelFitRecord.h
+++ b/include/lsst/meas/modelfit/ModelFitRecord.h
@@ -55,7 +55,7 @@ public:
     typedef afw::table::SortedCatalogT<ModelFitRecord const> ConstCatalog;
 
     CONST_PTR(ModelFitTable) getTable() const {
-        return boost::static_pointer_cast<ModelFitTable const>(afw::table::BaseRecord::getTable());
+        return std::static_pointer_cast<ModelFitTable const>(afw::table::BaseRecord::getTable());
     }
 
     PTR(Interpreter) getInterpreter() const;
@@ -123,14 +123,14 @@ public:
     void setInterpreter(PTR(Interpreter) interpreter) { _interpreter = interpreter; }
 
     /// @copydoc afw::table::BaseTable::clone
-    PTR(ModelFitTable) clone() const { return boost::static_pointer_cast<ModelFitTable>(_clone()); }
+    PTR(ModelFitTable) clone() const { return std::static_pointer_cast<ModelFitTable>(_clone()); }
 
     /// @copydoc afw::table::BaseTable::makeRecord
-    PTR(ModelFitRecord) makeRecord() { return boost::static_pointer_cast<ModelFitRecord>(_makeRecord()); }
+    PTR(ModelFitRecord) makeRecord() { return std::static_pointer_cast<ModelFitRecord>(_makeRecord()); }
 
     /// @copydoc afw::table::BaseTable::copyRecord
     PTR(ModelFitRecord) copyRecord(afw::table::BaseRecord const & other) {
-        return boost::static_pointer_cast<ModelFitRecord>(SimpleTable::copyRecord(other));
+        return std::static_pointer_cast<ModelFitRecord>(SimpleTable::copyRecord(other));
     }
 
     /// @copydoc afw::table::BaseTable::copyRecord
@@ -138,7 +138,7 @@ public:
         afw::table::BaseRecord const & other,
         afw::table::SchemaMapper const & mapper
     ) {
-        return boost::static_pointer_cast<ModelFitRecord>(afw::table::SimpleTable::copyRecord(other, mapper));
+        return std::static_pointer_cast<ModelFitRecord>(afw::table::SimpleTable::copyRecord(other, mapper));
     }
 
 protected:

--- a/include/lsst/meas/modelfit/UnitTransformedLikelihood.h
+++ b/include/lsst/meas/modelfit/UnitTransformedLikelihood.h
@@ -25,7 +25,7 @@
 #define LSST_MEAS_MODELFIT_UnitTransformedLikelihood_h_INCLUDED
 
 #include <vector>
-#include "boost/scoped_ptr.hpp"
+#include <memory>
 
 #include "ndarray.h"
 

--- a/include/lsst/meas/modelfit/UnitTransformedLikelihood.h
+++ b/include/lsst/meas/modelfit/UnitTransformedLikelihood.h
@@ -151,7 +151,7 @@ public:
 
 private:
     class Impl;
-    boost::scoped_ptr<Impl> _impl;
+    std::unique_ptr<Impl> _impl;
 };
 
 }}} // namespace lsst::meas::modelfit

--- a/include/lsst/meas/modelfit/psf.h
+++ b/include/lsst/meas/modelfit/psf.h
@@ -331,7 +331,7 @@ public:
 
 private:
     class Impl;
-    boost::scoped_ptr<Impl> _impl;
+    std::unique_ptr<Impl> _impl;
 };
 
 }}} // namespace lsst::meas::modelfit

--- a/include/lsst/meas/modelfit/psf.h
+++ b/include/lsst/meas/modelfit/psf.h
@@ -24,7 +24,7 @@
 #ifndef LSST_MEAS_MODELFIT_psf_h_INCLUDED
 #define LSST_MEAS_MODELFIT_psf_h_INCLUDED
 
-#include "boost/scoped_ptr.hpp"
+#include <memory>
 
 #include "lsst/pex/config.h"
 #include "lsst/shapelet/FunctorKeys.h"

--- a/python/lsst/meas/modelfit/CModel.i
+++ b/python/lsst/meas/modelfit/CModel.i
@@ -36,8 +36,8 @@
 %extend lsst::meas::modelfit::CModelStageResult {
 
     // An alternative accessor for ellipse
-    boost::shared_ptr<lsst::afw::geom::ellipses::Quadrupole> getEllipse() const {
-        return boost::make_shared<lsst::afw::geom::ellipses::Quadrupole>($self->ellipse);
+    std::shared_ptr<lsst::afw::geom::ellipses::Quadrupole> getEllipse() const {
+        return std::make_shared<lsst::afw::geom::ellipses::Quadrupole>($self->ellipse);
     }
 
 %pythoncode %{

--- a/src/CModel.cc
+++ b/src/CModel.cc
@@ -23,7 +23,7 @@
 #include <cstdlib>
 
 #include "boost/filesystem/path.hpp"
-#include "boost/make_shared.hpp"
+#include <memory>
 
 #include "ndarray/eigen.h"
 

--- a/src/CModel.cc
+++ b/src/CModel.cc
@@ -81,11 +81,11 @@ PTR(Prior) CModelStageControl::getPrior() const {
             / boost::filesystem::path("data")
             / boost::filesystem::path(priorName + ".fits");
         PTR(Mixture) mixture = Mixture::readFits(priorPath.string());
-        return boost::make_shared<MixturePrior>(mixture, "single-ellipse");
+        return std::make_shared<MixturePrior>(mixture, "single-ellipse");
     } else if (priorSource == "LINEAR") {
-        return boost::make_shared<SoftenedLinearPrior>(linearPriorConfig);
+        return std::make_shared<SoftenedLinearPrior>(linearPriorConfig);
     } else if (priorSource == "EMPIRICAL") {
-        return boost::make_shared<SemiEmpiricalPrior>(empiricalPriorConfig);
+        return std::make_shared<SemiEmpiricalPrior>(empiricalPriorConfig);
     } else {
         throw LSST_EXCEPT(
             meas::base::FatalAlgorithmError,
@@ -713,7 +713,7 @@ public:
         if (ctrl.doRecordTime) {
             startTime = daf::base::DateTime::now().nsecs();
         }
-        result.likelihood = boost::make_shared<UnitTransformedLikelihood>(
+        result.likelihood = std::make_shared<UnitTransformedLikelihood>(
             model, data.fixed, data.fitSys, *data.position,
             exposure, footprint, data.psf, UnitTransformedLikelihoodControl(ctrl.usePixelWeights)
         );
@@ -796,7 +796,7 @@ public:
         CModelStageControl const & ctrl, CModelStageResult & result, CModelStageData const & data,
         afw::image::Exposure<Pixel> const & exposure, afw::detection::Footprint const & footprint
     ) const {
-        result.likelihood = boost::make_shared<UnitTransformedLikelihood>(
+        result.likelihood = std::make_shared<UnitTransformedLikelihood>(
             model, data.fixed, data.fitSys, *data.position,
             exposure, footprint, data.psf, UnitTransformedLikelihoodControl(ctrl.usePixelWeights)
         );
@@ -848,7 +848,7 @@ public:
         Model::NameVector prefixes(2);
         prefixes[0] = "exp";
         prefixes[1] = "dev";
-        model = boost::make_shared<MultiModel>(components, prefixes);
+        model = std::make_shared<MultiModel>(components, prefixes);
     }
 
     // Create a blank result object, filling in only the things that don't change
@@ -1007,7 +1007,7 @@ CModelAlgorithm::CModelAlgorithm(
     afw::table::Schema & schema
 ) : _ctrl(ctrl), _impl(new Impl(ctrl))
 {
-    _impl->keys = boost::make_shared<CModelKeys>(
+    _impl->keys = std::make_shared<CModelKeys>(
         *_impl->initial.model, *_impl->exp.model, *_impl->dev.model,
         boost::ref(schema), name, false, ctrl
     );
@@ -1019,11 +1019,11 @@ CModelAlgorithm::CModelAlgorithm(
     afw::table::SchemaMapper & schemaMapper
 ) : _ctrl(ctrl), _impl(new Impl(ctrl))
 {
-    _impl->keys = boost::make_shared<CModelKeys>(
+    _impl->keys = std::make_shared<CModelKeys>(
         *_impl->initial.model, *_impl->exp.model, *_impl->dev.model,
         boost::ref(schemaMapper.editOutputSchema()), name, true, ctrl
     );
-    _impl->refKeys = boost::make_shared<CModelKeys>(
+    _impl->refKeys = std::make_shared<CModelKeys>(
         *_impl->initial.model, *_impl->exp.model, *_impl->dev.model,
         schemaMapper.getInputSchema(), name
     );

--- a/src/CModel.cc
+++ b/src/CModel.cc
@@ -21,9 +21,9 @@
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
 #include <cstdlib>
+#include <memory>
 
 #include "boost/filesystem/path.hpp"
-#include <memory>
 
 #include "ndarray/eigen.h"
 

--- a/src/DirectSamplingInterpreter.cc
+++ b/src/DirectSamplingInterpreter.cc
@@ -131,7 +131,7 @@ PTR(SamplingObjective) DirectSamplingInterpreter::makeObjective(
     PTR(SamplingInterpreter) self,
     PTR(Likelihood) likelihood
 ) const {
-    return boost::make_shared<DirectSamplingObjective>(self, likelihood);
+    return std::make_shared<DirectSamplingObjective>(self, likelihood);
 }
 
 void DirectSamplingInterpreter::_packParameters(

--- a/src/MarginalSamplingInterpreter.cc
+++ b/src/MarginalSamplingInterpreter.cc
@@ -161,7 +161,7 @@ PTR(SamplingObjective) MarginalSamplingInterpreter::makeObjective(
     PTR(SamplingInterpreter) self,
     PTR(Likelihood) likelihood
 ) const {
-    return boost::make_shared<MarginalSamplingObjective>(self, likelihood);
+    return std::make_shared<MarginalSamplingObjective>(self, likelihood);
 }
 
 void MarginalSamplingInterpreter::_packParameters(
@@ -321,7 +321,7 @@ void UnnestMarginalSamples::apply(
         directSigma.bottomRightCorner(amplitudeDim, amplitudeDim) = amplitudeSigma.asEigen();
         directComponents.push_back(Mixture::Component(marginalIter->weight, directMu, directSigma));
     }
-    PTR(Mixture) directPdf = boost::make_shared<Mixture>(
+    PTR(Mixture) directPdf = std::make_shared<Mixture>(
         parameterDim, boost::ref(directComponents), marginalPdf->getDegreesOfFreedom()
     );
     afw::table::BaseColumnView columns = directRecord.getSamples().getColumnView();

--- a/src/Mixture.cc
+++ b/src/Mixture.cc
@@ -109,7 +109,7 @@ PTR(Mixture) Mixture::project(int dim) const {
     for (const_iterator i = begin(); i != end(); ++i) {
         components.push_back(i->project(dim));
     }
-    return boost::make_shared<Mixture>(1, boost::ref(components), _df);
+    return std::make_shared<Mixture>(1, boost::ref(components), _df);
 }
 
 PTR(Mixture) Mixture::project(int dim1, int dim2) const {
@@ -118,7 +118,7 @@ PTR(Mixture) Mixture::project(int dim1, int dim2) const {
     for (const_iterator i = begin(); i != end(); ++i) {
         components.push_back(i->project(dim1, dim2));
     }
-    return boost::make_shared<Mixture>(2, boost::ref(components), _df);
+    return std::make_shared<Mixture>(2, boost::ref(components), _df);
 }
 
 void Mixture::normalize() {
@@ -377,7 +377,7 @@ void Mixture::updateEM(
 }
 
 PTR(Mixture) Mixture::clone() const {
-    return boost::make_shared<Mixture>(*this);
+    return std::make_shared<Mixture>(*this);
 }
 
 Mixture::Mixture(int dim, ComponentList & components, Scalar df) :
@@ -467,7 +467,7 @@ public:
                 )
             );
         }
-        return boost::make_shared<Mixture>(dim, boost::ref(components), df);
+        return std::make_shared<Mixture>(dim, boost::ref(components), df);
     }
 
     explicit MixtureFactory(std::string const & name) : tbl::io::PersistableFactory(name) {}

--- a/src/Model.cc
+++ b/src/Model.cc
@@ -392,11 +392,11 @@ PTR(Model) Model::make(BasisVector basisVector, NameVector const & prefixes, Cen
             }
         }
         if (center == FIXED_CENTER) {
-            return boost::make_shared<FixedCenterModel>(basisVector, nonlinearNames, amplitudeNames);
+            return std::make_shared<FixedCenterModel>(basisVector, nonlinearNames, amplitudeNames);
         } else {
             nonlinearNames.push_back("x");
             nonlinearNames.push_back("y");
-            return boost::make_shared<SingleCenterModel>(basisVector, nonlinearNames, amplitudeNames);
+            return std::make_shared<SingleCenterModel>(basisVector, nonlinearNames, amplitudeNames);
         }
     } else if (center == MULTI_CENTER) {
         for (std::size_t i = 0, n = basisVector.size(); i < n; ++i) {
@@ -413,7 +413,7 @@ PTR(Model) Model::make(BasisVector basisVector, NameVector const & prefixes, Cen
             nonlinearNames.push_back(prefixes[i] + "x");
             nonlinearNames.push_back(prefixes[i] + "y");
         }
-        return boost::make_shared<MultiCenterModel>(basisVector, nonlinearNames, amplitudeNames);
+        return std::make_shared<MultiCenterModel>(basisVector, nonlinearNames, amplitudeNames);
     }
     throw LSST_EXCEPT(
         pex::exceptions::LogicError,
@@ -434,12 +434,12 @@ PTR(Model) Model::make(PTR(shapelet::MultiShapeletBasis) basis, CenterEnum cente
     }
     if (center == FIXED_CENTER) {
         BasisVector basisVector(1, basis);
-        return boost::make_shared<FixedCenterModel>(basisVector, nonlinearNames, amplitudeNames);
+        return std::make_shared<FixedCenterModel>(basisVector, nonlinearNames, amplitudeNames);
     } else if (center == SINGLE_CENTER || center == MULTI_CENTER) {
         nonlinearNames.push_back("x");
         nonlinearNames.push_back("y");
         BasisVector basisVector(1, basis);
-        return boost::make_shared<SingleCenterModel>(basisVector, nonlinearNames, amplitudeNames);
+        return std::make_shared<SingleCenterModel>(basisVector, nonlinearNames, amplitudeNames);
     }
     throw LSST_EXCEPT(
         pex::exceptions::LogicError,
@@ -448,7 +448,7 @@ PTR(Model) Model::make(PTR(shapelet::MultiShapeletBasis) basis, CenterEnum cente
 }
 
 PTR(Model) Model::makeGaussian(CenterEnum center, double radius) {
-    PTR(shapelet::MultiShapeletBasis) basis = boost::make_shared<shapelet::MultiShapeletBasis>(1);
+    PTR(shapelet::MultiShapeletBasis) basis = std::make_shared<shapelet::MultiShapeletBasis>(1);
     ndarray::Array<double,2,2> matrix = ndarray::allocate(1, 1);
     matrix[0][0] = 1.0;
     basis->addComponent(radius, 0, matrix);

--- a/src/ModelFitRecord.cc
+++ b/src/ModelFitRecord.cc
@@ -62,11 +62,11 @@ public:
 private:
 
     virtual PTR(afw::table::BaseTable) _clone() const {
-        return boost::make_shared<ModelFitTableImpl>(*this);
+        return std::make_shared<ModelFitTableImpl>(*this);
     }
 
     virtual PTR(afw::table::BaseRecord) _makeRecord() {
-        return boost::make_shared<ModelFitRecordImpl>(getSelf<ModelFitTableImpl>());
+        return std::make_shared<ModelFitRecordImpl>(getSelf<ModelFitTableImpl>());
     }
 
 };
@@ -116,7 +116,7 @@ PTR(ModelFitTable) ModelFitTable::make(
             "Schema for ModelFit must contain at least the keys defined by makeMinimalSchema()."
         );
     }
-    return boost::make_shared<ModelFitTableImpl>(schema, sampleTable, interpreter);
+    return std::make_shared<ModelFitTableImpl>(schema, sampleTable, interpreter);
 }
 
 ModelFitTable::ModelFitTable(

--- a/src/PixelFitRegion.cc
+++ b/src/PixelFitRegion.cc
@@ -157,7 +157,7 @@ bool PixelFitRegion::applyEllipse(
 
 void PixelFitRegion::applyMask(afw::image::Mask<> const & mask, afw::geom::Point2D const & center) {
     Scalar originalArea = ellipse.getArea();
-    footprint = boost::make_shared<afw::detection::Footprint>(
+    footprint = std::make_shared<afw::detection::Footprint>(
         afw::geom::ellipses::Ellipse(ellipse, center),
         mask.getBBox(lsst::afw::image::PARENT)
     );

--- a/src/TruncatedGaussian.cc
+++ b/src/TruncatedGaussian.cc
@@ -84,7 +84,7 @@ TruncatedGaussian TruncatedGaussian::fromSeriesParameters(
              % n % hessian.rows() % hessian.cols()).str()
         );
     }
-    PTR(Impl) impl = boost::make_shared<Impl>(n);
+    PTR(Impl) impl = std::make_shared<Impl>(n);
     if (n == 1) {
         Scalar g = gradient[0];
         Scalar H = hessian(0,0);
@@ -200,7 +200,7 @@ TruncatedGaussian TruncatedGaussian::fromStandardParameters(
              % n % covariance.rows() % covariance.cols()).str()
         );
     }
-    PTR(Impl) impl = boost::make_shared<Impl>(n);
+    PTR(Impl) impl = std::make_shared<Impl>(n);
     if (n == 1) {
         Scalar mu = mean[0];
         Scalar Sigma = covariance(0,0);
@@ -495,13 +495,13 @@ TruncatedGaussianSampler::TruncatedGaussianSampler(
     if (parent.getDim() == 1) {
         switch (strategy) {
         case TruncatedGaussian::DIRECT_WITH_REJECTION:
-            _impl = boost::make_shared<SamplerImplDWR1>(
+            _impl = std::make_shared<SamplerImplDWR1>(
                 parent, parent._impl->mu, parent._impl->v, parent._impl->s
             );
             debugLog.debug<8>("Sampler: using DWR1");
             break;
         case TruncatedGaussian::ALIGN_AND_WEIGHT:
-            _impl = boost::make_shared<SamplerImplAAW1>(
+            _impl = std::make_shared<SamplerImplAAW1>(
                 parent, parent._impl->mu, parent._impl->v, parent._impl->s
             );
             debugLog.debug<8>("Sampler: using AAW1");
@@ -510,13 +510,13 @@ TruncatedGaussianSampler::TruncatedGaussianSampler(
     } else {
         switch (strategy) {
         case TruncatedGaussian::DIRECT_WITH_REJECTION:
-            _impl = boost::make_shared<SamplerImplDWR>(
+            _impl = std::make_shared<SamplerImplDWR>(
                 parent, parent._impl->mu, parent._impl->v, parent._impl->s
             );
             debugLog.debug<8>("Sampler: using DWR");
             break;
         case TruncatedGaussian::ALIGN_AND_WEIGHT:
-            _impl = boost::make_shared<SamplerImplAAW>(
+            _impl = std::make_shared<SamplerImplAAW>(
                 parent, parent._impl->mu, parent._impl->v, parent._impl->s
             );
             debugLog.debug<8>("Sampler: using AAW");

--- a/src/TruncatedGaussian.cc
+++ b/src/TruncatedGaussian.cc
@@ -32,7 +32,7 @@
 //
 
 #include "boost/math/special_functions/erf.hpp"
-#include "boost/make_shared.hpp"
+#include <memory>
 #include "Eigen/Eigenvalues"
 #include "Eigen/LU"
 

--- a/src/UnitSystem.cc
+++ b/src/UnitSystem.cc
@@ -31,7 +31,7 @@ namespace lsst { namespace meas { namespace modelfit {
 UnitSystem::UnitSystem(afw::coord::Coord const & position, Scalar mag) {
     double cdelt = (1.0*lsst::afw::geom::arcseconds).asDegrees();
     wcs = afw::image::makeWcs(position, afw::geom::Point2D(0.0, 0.0), cdelt, 0.0, 0.0, cdelt);
-    PTR(afw::image::Calib) calib_ = boost::make_shared<afw::image::Calib>();
+    PTR(afw::image::Calib) calib_ = std::make_shared<afw::image::Calib>();
     calib_->setFluxMag0(std::pow(10.0, mag/2.5));
     calib = calib_;
 }

--- a/src/UnitSystem.cc
+++ b/src/UnitSystem.cc
@@ -22,7 +22,7 @@
  */
 
 #include "boost/format.hpp"
-#include "boost/make_shared.hpp"
+#include <memory>
 
 #include "lsst/meas/modelfit/UnitSystem.h"
 

--- a/src/UnitTransformedLikelihood.cc
+++ b/src/UnitTransformedLikelihood.cc
@@ -25,7 +25,7 @@
 #include <numeric>
 
 #include "boost/format.hpp"
-#include "boost/make_shared.hpp"
+#include <memory>
 #include "ndarray/eigen.h"
 
 #include "lsst/afw/image/Calib.h"

--- a/src/optimizer.cc
+++ b/src/optimizer.cc
@@ -90,7 +90,7 @@ void OptimizerInterpreter::attachPdf(ModelFitRecord & record, Optimizer const & 
     components.push_back(
         Mixture::Component(1.0, optimizer.getParameters().asEigen(), sigma)
     );
-    record.setPdf(boost::make_shared<Mixture>(s.size(), boost::ref(components)));
+    record.setPdf(std::make_shared<Mixture>(s.size(), boost::ref(components)));
 }
 
 ndarray::Array<Scalar,1,1> OptimizerInterpreter::computeParameterQuantiles(
@@ -268,7 +268,7 @@ PTR(OptimizerObjective) OptimizerObjective::makeFromLikelihood(
     PTR(Likelihood) likelihood,
     PTR(Prior) prior
 ) {
-    return boost::make_shared<LikelihoodOptimizerObjective>(likelihood, prior);
+    return std::make_shared<LikelihoodOptimizerObjective>(likelihood, prior);
 }
 
 Scalar OptimizerObjective::computePrior(ndarray::Array<Scalar const,1,1> const & parameters) const {

--- a/src/psf.cc
+++ b/src/psf.cc
@@ -361,7 +361,7 @@ PsfFitter::PsfFitter(PsfFitterControl const & ctrl) :
     }
     ComponentVector components = vectorizeComponents(_ctrl);
 
-    _prior = boost::make_shared<PsfFitterPrior>(components);
+    _prior = std::make_shared<PsfFitterPrior>(components);
 
     Model::BasisVector basisVector;
     Model::NameVector nonlinearNames;
@@ -372,7 +372,7 @@ PsfFitter::PsfFitter(PsfFitterControl const & ctrl) :
 
         // Construct a MultiShapeletBasis with a single shapelet basis with this component
         int dim = shapelet::computeSize(i->second.order);
-        PTR(shapelet::MultiShapeletBasis) basis = boost::make_shared<shapelet::MultiShapeletBasis>(dim);
+        PTR(shapelet::MultiShapeletBasis) basis = std::make_shared<shapelet::MultiShapeletBasis>(dim);
         ndarray::Array<double,2,2> matrix = ndarray::allocate(dim, dim);
         matrix.asEigen().setIdentity();
         basis->addComponent(1.0, i->second.order, matrix);
@@ -404,7 +404,7 @@ PsfFitter::PsfFitter(PsfFitterControl const & ctrl) :
 
     }
 
-    _model = boost::make_shared<PsfFitterModel>(
+    _model = std::make_shared<PsfFitterModel>(
         basisVector, nonlinearNames, amplitudeNames, fixedNames, components
     );
 }
@@ -430,14 +430,14 @@ shapelet::MultiShapeletFunction PsfFitter::adapt(
     shapelet::MultiShapeletFunction const & previousFit,
     PTR(Model) previousModel
 ) const {
-    PTR(PsfFitterModel) m = boost::dynamic_pointer_cast<PsfFitterModel>(previousModel);
+    PTR(PsfFitterModel) m = std::dynamic_pointer_cast<PsfFitterModel>(previousModel);
     if (!m) {
         throw LSST_EXCEPT(
             pex::exceptions::InvalidParameterError,
             "Model passed to PsfFitter::adapt must have been constructed by PsfFitter"
         );
     }
-    return boost::static_pointer_cast<PsfFitterModel>(_model)->adapt(previousFit, *m);
+    return std::static_pointer_cast<PsfFitterModel>(_model)->adapt(previousFit, *m);
 }
 
 
@@ -451,7 +451,7 @@ shapelet::MultiShapeletFunction PsfFitter::apply(
         noiseSigma = _ctrl.defaultNoiseSigma;
     }
     shapelet::MultiShapeletFunction initial
-        = boost::static_pointer_cast<PsfFitterModel>(_model)->makeInitial(moments);
+        = std::static_pointer_cast<PsfFitterModel>(_model)->makeInitial(moments);
     return apply(image, initial, noiseSigma, pState);
 }
 
@@ -471,9 +471,9 @@ shapelet::MultiShapeletFunction PsfFitter::apply(
         = parameters[ndarray::view(_model->getNonlinearDim(), parameterDim)];
     ndarray::Array<Scalar,1,1> fixed = ndarray::allocate(_model->getFixedDim());
 
-    boost::static_pointer_cast<PsfFitterModel>(_model)->fillParameters(initial, nonlinear, amplitudes, fixed);
+    std::static_pointer_cast<PsfFitterModel>(_model)->fillParameters(initial, nonlinear, amplitudes, fixed);
 
-    PTR(Likelihood) likelihood = boost::make_shared<MultiShapeletPsfLikelihood>(
+    PTR(Likelihood) likelihood = std::make_shared<MultiShapeletPsfLikelihood>(
         image.getArray(), image.getXY0(), _model, noiseSigma, fixed
     );
     PTR(OptimizerObjective) objective = OptimizerObjective::makeFromLikelihood(likelihood, _prior);


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
