### PR TITLE
Set magnitude zero point if none exists

### DIFF
--- a/include/lsst/meas/modelfit/UnitSystem.h
+++ b/include/lsst/meas/modelfit/UnitSystem.h
@@ -48,11 +48,13 @@ struct UnitSystem {
      *  set such that unit flux is the given magnitude.  See @ref modelfitUnits for an explanation
      *  of why we frequently use this system.
      */
+    UnitSystem(afw::coord::Coord const & position, std::shared_ptr<const lsst::afw::image::Calib> calibIn,
+               double flux);
     UnitSystem(afw::coord::Coord const & position, Scalar mag);
 
     /// Construct a UnitSystem from a give Wcs and Calib
     UnitSystem(PTR(afw::image::Wcs const) wcs_, PTR(afw::image::Calib const) calib_) :
-        wcs(wcs_), calib(calib_)
+        wcs(wcs_), calib(validateCalib(calib_))
     {}
 
 // work around a bug in SWIG 3.0.2: mis-handling templated constructors
@@ -61,17 +63,21 @@ struct UnitSystem {
     /// Construct a UnitSystem by extracting the Wcs and Calib from an Exposure (implicit)
     template <typename T>
     UnitSystem(afw::image::Exposure<T> const & exposure) :
-        wcs(exposure.getWcs()), calib(exposure.getCalib())
+        wcs(exposure.getWcs()), calib(validateCalib(exposure.getCalib()))
     {}
 #else
     UnitSystem(afw::image::Exposure<float> const & exposure) :
-        wcs(exposure.getWcs()), calib(exposure.getCalib())
+        wcs(exposure.getWcs()), calib(validateCalib(exposure.getCalib()))
     {}
     UnitSystem(afw::image::Exposure<double> const & exposure) :
-        wcs(exposure.getWcs()), calib(exposure.getCalib())
+        wcs(exposure.getWcs()), calib(validateCalib(exposure.getCalib()))
     {}
-
 #endif
+
+private:
+    std::shared_ptr<const lsst::afw::image::Calib> validateCalib(
+        std::shared_ptr<const lsst::afw::image::Calib> calib_);
+    static std::shared_ptr<const lsst::afw::image::Calib> getDefaultCalib();
 };
 
 /**

--- a/src/CModel.cc
+++ b/src/CModel.cc
@@ -555,7 +555,7 @@ struct CModelStageData {
         Model const & model
     ) :
         measSysCenter(center), position(exposure.getWcs()->pixelToSky(center)),
-        measSys(exposure), fitSys(*position, exposure.getCalib()->getMagnitude(approxFlux)),
+        measSys(exposure), fitSys(*position, exposure.getCalib(), approxFlux),
         fitSysToMeasSys(*position, fitSys, measSys),
         parameters(ndarray::allocate(model.getNonlinearDim() + model.getAmplitudeDim())),
         nonlinear(parameters[ndarray::view(0, model.getNonlinearDim())]),

--- a/tests/testDefaultZeroPoint.py
+++ b/tests/testDefaultZeroPoint.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+# 
+# LSST Data Management System
+#
+# Copyright 2008-2016  AURA/LSST.
+# 
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the LSST License Statement and 
+# the GNU General Public License along with this program.  If not, 
+# see <https://www.lsstcorp.org/LegalNotices/>.
+#
+
+import unittest
+import numpy as np
+
+import lsst.afw.image as afwImage
+import lsst.afw.coord as afwCoord
+import lsst.afw.geom as afwGeom
+import lsst.meas.modelfit as measModel
+import lsst.utils
+
+class DefaultZeroPointTestCase(lsst.utils.tests.TestCase):
+    '''Test that calib objects containing invalid zero-points are replaced with default calib having a
+    zero-point of magnitude 27.
+    '''
+    def setUp(self):
+        '''Create two calibs, one with a valid zero-point and one without. Use these to create two UnitSystem
+        objects.
+        '''
+        self.mag2Flux = lambda m: 10.0**(m/2.5)
+        self.flux2Mag = lambda f: 2.5*np.log10(f)
+
+        calibNoZero = afwImage.Calib()
+        calibWithZero = afwImage.Calib()
+        calibWithZero.setFluxMag0(self.mag2Flux(25))
+
+        cdelt = (0.2*afwGeom.arcseconds).asDegrees()
+        position = afwCoord.IcrsCoord(45.0*afwGeom.degrees, 45.0*afwGeom.degrees)
+        wcs = afwImage.makeWcs(position, afwGeom.Point2D(), cdelt, 0.0, 0.0, cdelt)
+
+        self.unitNoZero = measModel.UnitSystem(wcs, calibNoZero)
+        self.unitWithZero = measModel.UnitSystem(wcs, calibWithZero)
+
+    def testZeroPoint(self):
+        '''Verify that the UnitSystem with an invalid calib gets populated with a valid calib, and that
+        nothing happens to the UnitSystem with a valid calib.
+        '''
+        magNoZero = self.flux2Mag(self.unitNoZero.calib.getFluxMag0()[0])
+        magWithZero = self.flux2Mag(self.unitWithZero.calib.getFluxMag0()[0])
+
+        print(magNoZero,magWithZero)
+
+        self.assertAlmostEqual(magNoZero, 27, 6)
+        self.assertAlmostEqual(magWithZero, 25, 6)
+
+    def tearDown(self):
+        del self.unitNoZero
+        del self.unitWithZero
+
+def suite():
+    '''Returns a suite containing all the test cases in this module.'''
+
+    lsst.utils.tests.init()
+
+    suites = []
+    suites += unittest.makeSuite(DefaultZeroPointTestCase)
+    suites += unittest.makeSuite(lsst.utils.tests.MemoryTestCase)
+    return unittest.TestSuite(suites)
+
+def run(shouldExit=False):
+    """Run the tests"""
+    lsst.utils.tests.run(suite(), shouldExit)
+
+if __name__ == '__main__':
+    run(True)


### PR DESCRIPTION
This code will now check that calib objects have a valid fluxMag0
(zero-point) set. If not a default calib object is used with a
reference zero-point of 27.