### PR TITLE
Remove boost::ref

### DIFF
--- a/src/CModel.cc
+++ b/src/CModel.cc
@@ -1009,7 +1009,7 @@ CModelAlgorithm::CModelAlgorithm(
 {
     _impl->keys = std::make_shared<CModelKeys>(
         *_impl->initial.model, *_impl->exp.model, *_impl->dev.model,
-        boost::ref(schema), name, false, ctrl
+        schema, name, false, ctrl
     );
 }
 
@@ -1021,7 +1021,7 @@ CModelAlgorithm::CModelAlgorithm(
 {
     _impl->keys = std::make_shared<CModelKeys>(
         *_impl->initial.model, *_impl->exp.model, *_impl->dev.model,
-        boost::ref(schemaMapper.editOutputSchema()), name, true, ctrl
+        schemaMapper.editOutputSchema(), name, true, ctrl
     );
     _impl->refKeys = std::make_shared<CModelKeys>(
         *_impl->initial.model, *_impl->exp.model, *_impl->dev.model,

--- a/src/MarginalSamplingInterpreter.cc
+++ b/src/MarginalSamplingInterpreter.cc
@@ -321,7 +321,7 @@ void UnnestMarginalSamples::apply(
         directComponents.push_back(Mixture::Component(marginalIter->weight, directMu, directSigma));
     }
     PTR(Mixture) directPdf = std::make_shared<Mixture>(
-        parameterDim, boost::ref(directComponents), marginalPdf->getDegreesOfFreedom()
+        parameterDim, directComponents, marginalPdf->getDegreesOfFreedom()
     );
     afw::table::BaseColumnView columns = directRecord.getSamples().getColumnView();
     directPdf->updateEM(columns[_directInterpreter->getParameterKey()],

--- a/src/Mixture.cc
+++ b/src/Mixture.cc
@@ -109,7 +109,7 @@ PTR(Mixture) Mixture::project(int dim) const {
     for (const_iterator i = begin(); i != end(); ++i) {
         components.push_back(i->project(dim));
     }
-    return std::make_shared<Mixture>(1, boost::ref(components), _df);
+    return std::make_shared<Mixture>(1, components, _df);
 }
 
 PTR(Mixture) Mixture::project(int dim1, int dim2) const {
@@ -118,7 +118,7 @@ PTR(Mixture) Mixture::project(int dim1, int dim2) const {
     for (const_iterator i = begin(); i != end(); ++i) {
         components.push_back(i->project(dim1, dim2));
     }
-    return std::make_shared<Mixture>(2, boost::ref(components), _df);
+    return std::make_shared<Mixture>(2, components, _df);
 }
 
 void Mixture::normalize() {
@@ -467,7 +467,7 @@ public:
                 )
             );
         }
-        return std::make_shared<Mixture>(dim, boost::ref(components), df);
+        return std::make_shared<Mixture>(dim, components, df);
     }
 
     explicit MixtureFactory(std::string const & name) : tbl::io::PersistableFactory(name) {}

--- a/src/optimizer.cc
+++ b/src/optimizer.cc
@@ -90,7 +90,7 @@ void OptimizerInterpreter::attachPdf(ModelFitRecord & record, Optimizer const & 
     components.push_back(
         Mixture::Component(1.0, optimizer.getParameters().asEigen(), sigma)
     );
-    record.setPdf(std::make_shared<Mixture>(s.size(), boost::ref(components)));
+    record.setPdf(std::make_shared<Mixture>(s.size(), components));
 }
 
 ndarray::Array<Scalar,1,1> OptimizerInterpreter::computeParameterQuantiles(


### PR DESCRIPTION
For use here it is no longer needed because std::make_shared
uses forwarding references internally.