### PR TITLE
DM-10066: Provide utility function for wrapping operator<<

### DIFF
--- a/python/lsst/meas/modelfit/mixture.cc
+++ b/python/lsst/meas/modelfit/mixture.cc
@@ -61,13 +61,8 @@ static PyMixtureComponent declareMixtureComponent(py::module &mod) {
             "dim1"_a, "dim2"_a);
     cls.def(py::init<int>(), "dim"_a);
     cls.def(py::init<Scalar, Vector const &, Matrix const &>(), "weight"_a, "mu"_a, "sigma"_a);
-    auto streamStr = [](MixtureComponent const &self) {
-        std::ostringstream os;
-        os << self;
-        return os.str();
-    };
-    cls.def("__str__", streamStr);
-    cls.def("__repr__", streamStr);
+    utils::python::addOutputOp(cls, "__str__");
+    utils::python::addOutputOp(cls, "__repr__");
     return cls;
 }
 
@@ -133,14 +128,8 @@ static PyMixture declareMixture(py::module &mod) {
     cls.def("clone", &Mixture::clone);
     cls.def(py::init<int, Mixture::ComponentList &, Scalar>(), "dim"_a, "components"_a,
             "df"_a = std::numeric_limits<Scalar>::infinity());
-    auto streamStr = [](Mixture const &self) {
-        std::ostringstream os;
-        os << self;
-        return os.str();
-    };
-    return cls;
-    cls.def("__str__", streamStr);
-    cls.def("__repr__", streamStr);
+    utils::python::addOutputOp(cls, "__str__");
+    utils::python::addOutputOp(cls, "__repr__");
     return cls;
 }
 


### PR DESCRIPTION
This PR replaces trivial pybind11 wrappers of operator<< with calls to `wrapOutputOp`, which is introduced in lsst/utils#47. Non-trivial wrappers (typically ones that add extra information to `__repr__`) are left untouched.