### PR TITLE
DM-13898: Remove the XYTransform classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+language: python
+matrix:
+  include:
+    - python: '3.6'
+      install:
+      - pip install flake8
+      script: flake8

--- a/examples/drawGaussian.py
+++ b/examples/drawGaussian.py
@@ -86,6 +86,7 @@ def display(tg, nSamples=5000, strategy=None):
     p.draw()
     return p
 
+
 if __name__ == "__main__":
     if True:
         angle = -numpy.pi/6

--- a/examples/fitPsfs.py
+++ b/examples/fitPsfs.py
@@ -65,6 +65,7 @@ def fitPsfImage(image, fitters):
         n += 1
     printResidualStatistics(image, msf, n)
 
+
 ctrls = [
     lsst.meas.modelfit.GeneralPsfFitterControl(),
     lsst.meas.modelfit.GeneralPsfFitterControl(),
@@ -98,6 +99,7 @@ def main(filenames):
         image.getArray()[:, :] /= image.getArray()[:, :].max()
         print(filename)
         fitPsfImage(image, fitters)
+
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/examples/mixtureEM.py
+++ b/examples/mixtureEM.py
@@ -1,5 +1,5 @@
-from builtins import range
 #!/usr/bin/env python
+from builtins import range
 #
 # LSST Data Management System
 # Copyright 2008-2013 LSST Corporation.
@@ -24,7 +24,6 @@ from builtins import range
 
 import numpy
 from matplotlib import pyplot
-import mpl_toolkits.mplot3d
 
 import lsst.meas.modelfit
 
@@ -32,13 +31,13 @@ rng = lsst.afw.math.Random()
 
 
 def makeRandomMixture(nDim, nComponents, df=float("inf")):
-    l = lsst.meas.modelfit.Mixture[nDim].ComponentList()
+    componentList = lsst.meas.modelfit.Mixture[nDim].ComponentList()
     for i in range(nComponents):
         mu = numpy.random.randn(nDim)*4
         a = numpy.random.randn(nDim+1, nDim)
         sigma = numpy.dot(a.transpose(), a) + numpy.identity(nDim)
-        l.append(lsst.meas.modelfit.Mixture[nDim].Component(numpy.random.rand(), mu, sigma))
-    return lsst.meas.modelfit.Mixture[nDim](l, df)
+        componentList.append(lsst.meas.modelfit.Mixture[nDim].Component(numpy.random.rand(), mu, sigma))
+    return lsst.meas.modelfit.Mixture[nDim](componentList, df)
 
 
 def initPlot1(fig, x, w):
@@ -101,6 +100,7 @@ def finishPlot2(initData):
     axes2.set_ylim(-15, 15)
     axes2.set_xlim(-15, 15)
 
+
 initPlot = {1: initPlot1, 2: initPlot2}
 plotMixture = {1: plotMixture1, 2: plotMixture2}
 finishPlot = {1: finishPlot1, 2: finishPlot2}
@@ -139,10 +139,10 @@ def doTestEM(inMixture, label, nSamples=100000, scatter=0.8, nIterations=50, imp
 
 
 if __name__ == "__main__":
-    #m1 = makeRandomMixture(1, 3)
-    #doTestEM(m1, "3x Gaussian, 1-d, uniform weights")
-    #m2 = makeRandomMixture(1, 3, df=4)
-    #doTestEM(m2, "3x Student's T, 1-d, uniform weights")
+    # m1 = makeRandomMixture(1, 3)
+    # doTestEM(m1, "3x Gaussian, 1-d, uniform weights")
+    # m2 = makeRandomMixture(1, 3, df=4)
+    # doTestEM(m2, "3x Student's T, 1-d, uniform weights")
     m3 = makeRandomMixture(2, 3)
     doTestEM(m3, "3x Gaussian, 2-d, uniform weights")
     doTestEM(m3, "3x Gaussian, 2-d, importance weights", importanceSample=True)

--- a/examples/saveBigCatalog.py
+++ b/examples/saveBigCatalog.py
@@ -45,13 +45,16 @@ def main(nRecords, nSamplesPerRecord):
     res0 = resource.getrusage(resource.RUSAGE_SELF)
     catalog.writeFits("tmp.fits")
     res1 = resource.getrusage(resource.RUSAGE_SELF)
-    print("Save complete: system=%f, user=%f" % (res1.ru_stime - res0.ru_utime, res1.ru_utime - res0.ru_utime))
+    print("Save complete: system=%f, user=%f" %
+          (res1.ru_stime - res0.ru_utime, res1.ru_utime - res0.ru_utime))
     print("Loading catalog")
     res0 = resource.getrusage(resource.RUSAGE_SELF)
-    catalog1 = lsst.meas.modelfit.ModelFitCatalog.readFits("tmp.fits")
+    lsst.meas.modelfit.ModelFitCatalog.readFits("tmp.fits")
     res1 = resource.getrusage(resource.RUSAGE_SELF)
-    print("Load complete: system=%f, user=%f" % (res1.ru_stime - res0.ru_utime, res1.ru_utime - res0.ru_utime))
+    print("Load complete: system=%f, user=%f" %
+          (res1.ru_stime - res0.ru_utime, res1.ru_utime - res0.ru_utime))
     os.remove("tmp.fits")
+
 
 if __name__ == "__main__":
     import sys

--- a/include/lsst/meas/modelfit/UnitSystem.h
+++ b/include/lsst/meas/modelfit/UnitSystem.h
@@ -29,7 +29,6 @@
 #include "lsst/afw/geom/SkyWcs.h"
 #include "lsst/afw/image/Calib.h"
 #include "lsst/afw/geom/AffineTransform.h"
-#include "lsst/afw/geom/XYTransform.h"
 
 #include "lsst/meas/modelfit/common.h"
 

--- a/python/lsst/meas/modelfit/display/cModelDisplay.py
+++ b/python/lsst/meas/modelfit/display/cModelDisplay.py
@@ -218,7 +218,7 @@ def reconstructCModel(exposure, record, config):
     # fetch the aperture corrections, if this fails set it to one
     try:
         apCorr = record.get("{}_apCorr".format(baseName))
-    except:
+    except Exception:
         print("Warning, problem retrieving aperture correction, using a value"
               " of 1")
         apCorr = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[flake8]
+max-line-length = 110
+ignore = E133, E226, E228, N802, N803, N806
+exclude = __init__.py
+
+[tool:pytest]
+addopts = --flake8
+flake8-ignore = E133 E226 E228 N802 N803 N806

--- a/tests/test_cModelPlugins.py
+++ b/tests/test_cModelPlugins.py
@@ -116,6 +116,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
 def setup_module(module):
     lsst.utils.tests.init()
 
+
 if __name__ == "__main__":
     lsst.utils.tests.init()
     unittest.main()

--- a/tests/test_generalShapeletPsfApproxPlugins.py
+++ b/tests/test_generalShapeletPsfApproxPlugins.py
@@ -202,6 +202,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
 def setup_module(module):
     lsst.utils.tests.init()
 
+
 if __name__ == "__main__":
     lsst.utils.tests.init()
     unittest.main()

--- a/tests/test_generalShapeletPsfModels.py
+++ b/tests/test_generalShapeletPsfModels.py
@@ -23,7 +23,6 @@
 import unittest
 import numpy
 import os
-import time
 
 import lsst.utils.tests
 import lsst.shapelet
@@ -182,6 +181,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
 
 def setup_module(module):
     lsst.utils.tests.init()
+
 
 if __name__ == "__main__":
     lsst.utils.tests.init()

--- a/tests/test_integrals.py
+++ b/tests/test_integrals.py
@@ -52,6 +52,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
 def setup_module(module):
     lsst.utils.tests.init()
 
+
 if __name__ == "__main__":
     lsst.utils.tests.init()
     unittest.main()

--- a/tests/test_mixture.py
+++ b/tests/test_mixture.py
@@ -47,13 +47,13 @@ class MixtureTestCase(lsst.utils.tests.TestCase):
 
     @staticmethod
     def makeRandomMixture(nDim, nComponents, df=float("inf")):
-        l = []
+        componentList = []
         for i in range(nComponents):
             mu = numpy.random.randn(nDim)*4
             a = numpy.random.randn(nDim+1, nDim)
             sigma = numpy.dot(a.transpose(), a) + numpy.identity(nDim)
-            l.append(lsst.meas.modelfit.Mixture.Component(numpy.random.rand(), mu, sigma))
-        return lsst.meas.modelfit.Mixture(nDim, l, df)
+            componentList.append(lsst.meas.modelfit.Mixture.Component(numpy.random.rand(), mu, sigma))
+        return lsst.meas.modelfit.Mixture(nDim, componentList, df)
 
     def testSwig(self):
         """Test that Swig correctly wrapped tricky things.
@@ -75,8 +75,8 @@ class MixtureTestCase(lsst.utils.tests.TestCase):
         self.assertFloatsAlmostEqual(m1.evaluate(m1[1], numpy.array([0.0], dtype=float)),
                                      m1[1].weight*(2.0*numpy.pi)**(-0.5))
         self.assertFloatsAlmostEqual(m1.evaluate(numpy.array([0.0], dtype=float)),
-                                     (m1[0].weight*numpy.exp(-0.125)/2 + m1[1].weight + m1[2].weight)
-                                     * (2.0*numpy.pi)**(-0.5))
+                                     (m1[0].weight*numpy.exp(-0.125)/2 + m1[1].weight + m1[2].weight) *
+                                     (2.0*numpy.pi)**(-0.5))
 
     def testGaussian(self):
         """Test that our implementations for a single-component Gaussian are correct.
@@ -88,8 +88,8 @@ class MixtureTestCase(lsst.utils.tests.TestCase):
         x = numpy.random.randn(20, 2)
         p = numpy.zeros(20, dtype=float)
         m.evaluate(x, p)
-        z = ((x - mu)[:, numpy.newaxis, :] * fisher[numpy.newaxis, :, :, ]
-             * (x - mu)[:, :, numpy.newaxis]).sum(axis=2).sum(axis=1)
+        z = ((x - mu)[:, numpy.newaxis, :] * fisher[numpy.newaxis, :, :, ] *
+             (x - mu)[:, :, numpy.newaxis]).sum(axis=2).sum(axis=1)
         self.assertFloatsAlmostEqual(p, numpy.exp(-0.5*z) / numpy.linalg.det(2*numpy.pi*sigma)**0.5)
         x = numpy.zeros((1000000, 2), dtype=float)
         m.draw(self.rng, x)
@@ -185,6 +185,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
 
 def setup_module(module):
     lsst.utils.tests.init()
+
 
 if __name__ == "__main__":
     lsst.utils.tests.init()


### PR DESCRIPTION
Note that this actually just consists of deleting an unused `include` statement. It could be merged before the changes in afw and whether or not RFC-470 is accepted.