### PR TITLE
DM-9937: Add noexcept specifiers to applicable methods in afw

### DIFF
--- a/include/lsst/meas/modelfit/Mixture.h
+++ b/include/lsst/meas/modelfit/Mixture.h
@@ -336,7 +336,7 @@ public:
         return os;
     }
 
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
 
 protected:
 


### PR DESCRIPTION
lsst/afw#366 adds a `noexcept` specifier to `afw::table::io::Persistence::isPersistable`. This PR adds a `noexcept` specifier to all methods that override `Persistence::isPersistable`, as required by type safety.