### PR TITLE
DM-49554: Do not attempt forced photometry in NO_DATA regions

### DIFF
--- a/tests/test_doubleShapeletPsfApprox.py
+++ b/tests/test_doubleShapeletPsfApprox.py
@@ -180,7 +180,7 @@ class DoubleShapeletPsfApproxTestMixin:
         config.copyColumns = {"id": "objectId", "parent": "parentObjectId"}
         self.setupTaskConfig(config)
         config.slots.centroid = "base_TransformedCentroid"
-        config.plugins.names |= ["base_TransformedCentroid"]
+        config.plugins.names |= ["base_TransformedCentroid", "base_PixelFlags"]
         refSchema = lsst.afw.table.SourceTable.makeMinimalSchema()
         refCentroidKey = lsst.afw.table.Point2DKey.addFields(refSchema, "centroid", "centroid", "pixel")
         refSchema.getAliasMap().set("slot_Centroid", "centroid")

--- a/tests/test_generalShapeletPsfApproxPlugins.py
+++ b/tests/test_generalShapeletPsfApproxPlugins.py
@@ -110,7 +110,9 @@ class GeneralShapeletPsfApproxPluginsTestCase(lsst.utils.tests.TestCase):
         config.slots.modelFlux = None
         config.doReplaceWithNoise = False
         config.slots.centroid = "base_TransformedCentroid"
-        config.plugins.names = ["base_TransformedCentroid", "modelfit_GeneralShapeletPsfApprox"]
+        config.plugins.names = ["base_TransformedCentroid",
+                                "base_PixelFlags",
+                                "modelfit_GeneralShapeletPsfApprox"]
         config.plugins["modelfit_GeneralShapeletPsfApprox"].sequence = ["SingleGaussian"]
         config.copyColumns = {"id": "objectId", "parent": "parentObjectId"}
         refCat = lsst.afw.table.SourceCatalog(self.schema)


### PR DESCRIPTION
Add base_PixelFlag to tests
Due to the requirement to run the base_PixelFlag plugin for forced photometry, all tests that perform forced photometry need this plugin adding to their configs.